### PR TITLE
Replace std::list with FastCircularQueue

### DIFF
--- a/bonsai/Makefile
+++ b/bonsai/Makefile
@@ -23,7 +23,7 @@ DBG:=
 OS:=$(shell uname)
 FLAGS=
 
-OPT_MINUS_OPENMP= -O3 -funroll-loops -flto\
+OPT_MINUS_OPENMP= -O3 -funroll-loops\
 	  -pipe -fno-strict-aliasing -march=native -mpclmul $(FLAGS) $(EXTRA) -DHLL_HEADER_ONLY
 OPT=$(OPT_MINUS_OPENMP) -fopenmp
 XXFLAGS=-fno-rtti
@@ -90,10 +90,10 @@ clhash.o: ../clhash/src/clhash.c
 	$(CC) $(CFLAGS) $(INCLUDE) -c $< -o $@ $(LIB) $(ZCOMPILE_FLAGS)
 
 test/%.o: test/%.cpp
-	$(CXX) $(CXXFLAGS) $(DBG) $(INCLUDE) $(LD) -c $< -o $@ $(LIB)
+	$(CXX) $(CXXFLAGS) $(DBG) $(INCLUDE) $(LD) -DNDEBUG=0 -c $< -o $@ $(LIB)
 
 test/%.zo: test/%.cpp
-	$(CXX) $(CXXFLAGS) $(DBG) $(INCLUDE) $(LD) -c $< -o $@ $(ZCOMPILE_FLAGS)
+	$(CXX) $(CXXFLAGS) $(DBG) $(INCLUDE) $(LD) -DNDEBUG=0 -c $< -o $@ $(ZCOMPILE_FLAGS)
 
 %.o: %.cpp
 	$(CXX) $(CXXFLAGS) $(DBG) $(INCLUDE) $(LD) -DNDEBUG -c $< -o $@ $(LIB)
@@ -131,11 +131,11 @@ lib/libbonsai.a: $(OBJS)
 tests: clean unit
 
 unit: $(OBJS) $(TEST_OBJS)
-	$(CXX) $(CXXFLAGS) $(INCLUDE) $(TEST_OBJS) $(LD) $(OBJS) -o $@ $(LIB)
+	$(CXX) $(CXXFLAGS) $(INCLUDE) $(TEST_OBJS) $(LD) $(OBJS) -DNDEBUG=0 -o $@ $(LIB)
 	# $(CXX) $(CXXFLAGS) $(DBG) $(INCLUDE) test/hll.o test/main.o $(LD) $(OBJS) -o $@ $(LIB)
 
 zunit: $(ZOBJS) $(ZTEST_OBJS)
-	$(CXX) $(CXXFLAGS) $(INCLUDE) $(ZTEST_OBJS) $(LD) $(ALL_ZOBJS) -o $@ $(LIB) $(ZCOMPILE_FLAGS)
+	$(CXX) $(CXXFLAGS) $(INCLUDE) $(ZTEST_OBJS) $(LD) $(ALL_ZOBJS) -DNDEBUG=0 -o $@ $(LIB) $(ZCOMPILE_FLAGS)
 
 
 clean:

--- a/bonsai/include/circular_buffer.h
+++ b/bonsai/include/circular_buffer.h
@@ -32,7 +32,7 @@ static inline uint8_t roundup(uint8_t x) {
     return ++x;
 }
 
-template<typename T, typename SizeType=uint32_t, typename=std::enable_if_t<std::is_unsigned_v<T>>>
+template<typename T, typename SizeType=uint32_t>
 class FastCircularQueue {
     // A circular queue in which extra memory has been allocated up to a power of two.
     // This allows us to use bitmasks instead of modulus operations.
@@ -42,6 +42,7 @@ class FastCircularQueue {
     SizeType start_;
     SizeType  stop_;
     T        *data_;
+    static_assert(std::is_unsigned_v<SizeType>, "Must be unsigned");
 
 public:
     using size_type = SizeType;
@@ -80,8 +81,8 @@ public:
         bool operator<=(const iterator &other) const noexcept {
             return pos_ <= other.pos_;
         }
-        bool operator<(const iterator &other) const noexcept {
-            return pos_ < other.pos_;
+        bool operator>(const iterator &other) const noexcept {
+            return pos_ > other.pos_;
         }
         bool operator>=(const iterator &other) const noexcept {
             return pos_ >= other.pos_;
@@ -150,7 +151,7 @@ public:
         new_size = roundup(new_size);
         auto tmp = std::realloc(data_, new_size);
         if(tmp == nullptr) throw std::bad_alloc();
-        data_ = tmp;
+        data_ = static_cast<T *>(tmp);
         if(start_ == stop_) {
             if(start_) {
                 stop_ = mask_ + 1;
@@ -239,6 +240,6 @@ public:
 
 }; // FastCircularQueue
 template<typename T, typename SizeType=uint32_t>
-using deque = FastCircularQueue<T, Sizetype>;
+using deque = FastCircularQueue<T, SizeType>;
 
 } // namespace circ

--- a/bonsai/include/circular_buffer.h
+++ b/bonsai/include/circular_buffer.h
@@ -6,6 +6,7 @@
 #include <stdexcept>   // For std::bad_alloc
 #include <string>      // for std::string [for exception handling]
 #include <type_traits> // For std::enable_if_t/std::is_unsigned_v
+#include <cstring>     // For std::memcpy
 
 namespace circ {
 using std::size_t;
@@ -37,10 +38,10 @@ class FastCircularQueue {
     // This allows us to use bitmasks instead of modulus operations.
     // This circular queue is NOT threadsafe. Its purpose is creating a double-ended queue without
     // the overhead of a doubly-linked list.
-    const SizeType mask_;
-    SizeType      start_;
-    SizeType       stop_;
-    T             *data_;
+    SizeType  mask_;
+    SizeType start_;
+    SizeType  stop_;
+    T        *data_;
 
 public:
     using size_type = SizeType;
@@ -144,12 +145,49 @@ public:
         assert((mask_ & (mask_ - 1)) == 0);
         if(data_ == nullptr) throw std::bad_alloc();
     }
+    void resize(size_type new_size) {
+        if(__builtin_expect(new_size < mask_, 0)) throw std::runtime_error("Attempting to resize to value smaller than queue's size, either from user error or overflowing the size_type. Abort!");
+        new_size = roundup(new_size);
+        auto tmp = std::realloc(data_, new_size);
+        if(tmp == nullptr) throw std::bad_alloc();
+        data_ = tmp;
+        if(start_ == stop_) {
+            if(start_) {
+                stop_ = mask_ + 1;
+                auto tmp = static_cast<T *>(std::malloc((stop_) * sizeof(T)));
+                if(tmp == nullptr) throw std::bad_alloc();
+                std::memcpy(tmp, data_ + start_, (stop_ - start_) * sizeof(T));
+                std::memcpy(tmp + (stop_ - start_), data_, stop_ * sizeof(T));
+                std::memcpy(data_, tmp, (stop_) * sizeof(T));
+                std::free(tmp);
+                start_ = 0;
+            }
+        } else if(stop_ < start_) {
+            auto tmp = static_cast<T *>(std::malloc((mask_ + 1) * sizeof(T)));
+            if(tmp == nullptr) throw std::bad_alloc();
+            std::memcpy(tmp, data_ + start_, ((mask_ + 1) - start_) * sizeof(T));
+            std::memcpy(tmp + ((mask_ + 1) - start_), data_, stop_ * sizeof(T));
+            auto sz = (stop_ - start_) & mask_;
+            std::memcpy(data_, tmp, sz);
+            std::free(tmp);
+            start_ = 0;
+            stop_ = sz;
+        }
+        mask_ = ((mask_ + 1) << 1) - 1;
+    }
+    // Does not yet implement push_front.
     template<typename... Args>
-    T &push(Args &&... args) {
+    T &push_back(Args &&... args) {
         size_type ind = stop_;
         ++stop_; stop_ &= mask_;
-        if(__builtin_expect(stop_ == start_, 0)) throw std::runtime_error(std::string("Overfull buffer of size ") + std::to_string(capacity()) + ". Abort!");
+        if(__builtin_expect(stop_ == start_, 0)) {
+            resize((mask_ + 1) << 1);
+        }
         return *(new(data_ + ind) T(std::forward<Args>(args)...));
+    }
+    template<typename... Args>
+    T &emplace_back(Args &&... args) {
+        return push_back(std::forward<Args>(args)...); // Interface compatibility.
     }
     T pop() {
         if(__builtin_expect(stop_ == start_, 0)) throw std::runtime_error("Popping item from empty buffer. Abort!");
@@ -157,19 +195,50 @@ public:
         start_ &= mask_;
         return ret; // If unused, the std::move causes it to leave scope and therefore be destroyed.
     }
+    T pop_back() {
+        if(__builtin_expect(stop_ == start_, 0)) throw std::runtime_error("Popping item from empty buffer. Abort!");
+        T ret(std::move(data_[--stop_]));
+        start_ &= mask_;
+        return ret; // If unused, the std::move causes it to leave scope and therefore be destroyed.
+    }
+    T pop_front() {
+        return pop(); // Interface compatibility with std::list.
+    }
     template<typename... Args>
     T push_pop(Args &&... args) {
         T ret(pop());
         push(std::forward<Args>(args)...);
         return ret;
     }
-    ~FastCircularQueue() noexcept {
-        for(size_type i(start_); i != stop_; data_[i++].~T(), i &= mask_);
+    T &back() {
+        return data_[stop_ - 1];
+    }
+    const T &back() const {
+        return data_[stop_ - 1];
+    }
+    T &front() {
+        return data_[start_];
+    }
+    const T &front() const {
+        return data_[start_];
+    }
+    ~FastCircularQueue() {
+        if constexpr(std::is_destructible_v<T>) {
+            for(size_type i(start_); i != stop_; data_[i++].~T(), i &= mask_);
+        }
         std::free(data_);
     }
     size_type capacity() const noexcept {return mask_ + 1;}
     size_type size()     const noexcept {return (stop_ - start_) & mask_;}
-    
-} // FastCircularQueue
+    void clear() {
+        if constexpr(std::is_destructible_v<T>) {
+            for(size_type i(start_); i != stop_; data_[i++].~T(), i &= mask_);
+        }
+        start_ = stop_ = 0;
+    }
+
+}; // FastCircularQueue
+template<typename T, typename SizeType=uint32_t>
+using deque = FastCircularQueue<T, Sizetype>;
 
 } // namespace circ

--- a/bonsai/include/qmap.h
+++ b/bonsai/include/qmap.h
@@ -44,7 +44,7 @@ class QueueMap {
     std::map<ElScore<T, ScoreType>, u32> map_;
     const size_t                         wsz_;  // window size to keep
     public:
-    QueueMap(size_t wsz): list_(wsz + 1), wsz_(wsz) {}
+    QueueMap(size_t wsz): list_(wsz), wsz_(wsz) {}
     INLINE void add(const PairType &el) {
         if(auto it(map_.lower_bound(el)); it != map_.end()) {
             if(it->first == el) ++it->second;

--- a/bonsai/include/qmap.h
+++ b/bonsai/include/qmap.h
@@ -5,7 +5,7 @@
 #include <cstdio>
 #include <cinttypes>
 #include <map>
-#include <list>
+#include "circular_buffer.h"
 #include <vector>
 
 #include "util.h"
@@ -38,12 +38,13 @@ class QueueMap {
     using PairType           = ElScore<T, ScoreType>;
     using map_iterator       = typename std::map<ElScore<T, ScoreType>, unsigned>::iterator;
     using const_map_iterator = typename std::map<ElScore<T, ScoreType>, unsigned>::const_iterator;
+    using list_type = circ::deque<ElScore<T, ScoreType>, u32>;
 
-    std::list<ElScore<T, ScoreType>>         list_;
-    std::map<ElScore<T, ScoreType>, unsigned> map_;
+    list_type list_;
+    std::map<ElScore<T, ScoreType>, u32> map_;
     const size_t                         wsz_;  // window size to keep
     public:
-    QueueMap(size_t wsz): wsz_(wsz) {}
+    QueueMap(size_t wsz): list_(wsz + 1), wsz_(wsz) {}
     INLINE void add(const PairType &el) {
         if(auto it(map_.lower_bound(el)); it != map_.end()) {
             if(it->first == el) ++it->second;
@@ -67,13 +68,11 @@ class QueueMap {
     }
     // Do a std::enable_if that involves moving the element if it's by reference?
     u64 next_value(const T el, const u64 score) {
-        list_.emplace_back(el, score);
-        add(list_.back());
+        add(list_.emplace_back(el, score));
         if(list_.size() > wsz_) {
             //fprintf(stderr, "list size: %zu. wsz: %zu\n", list_.size(), wsz_);
             //map_.del(list_.front());
-            del(list_.front());
-            list_.pop_front();
+            del(list_.pop_front());
         }
         return list_.size() == wsz_ ? map_.begin()->first.el_: BF;
         // Signal a window that is not filled by 0xFFFFFFFFFFFFFFFF


### PR DESCRIPTION
This eliminates news/deletes from the QueueMap data structure and improves locality. This might not make much of a difference, but reducing memory management contention and cache coherence should at least not be a bad thing.