### PR TITLE
Winnowing k > len(seq) > w

### DIFF
--- a/include/bonsai/qmap.h
+++ b/include/bonsai/qmap.h
@@ -87,6 +87,7 @@ class QueueMap {
     }
     size_t size() const {return wsz_;}
     size_t n_in_queue() const {return list_.size();}
+    bool partially_full() const {auto n = n_in_queue(); return n > 0u && n < wsz_;}
 };
 
 using qmap_t = QueueMap<u64, u64>;

--- a/include/bonsai/qmap.h
+++ b/include/bonsai/qmap.h
@@ -79,7 +79,10 @@ class QueueMap {
     T next_value(const T el, const T score) {
         add(list_.emplace_back(el, score));
         if(list_.size() > wsz_) del(list_.pop_front());
-        return list_.size() == wsz_ ? map_.begin()->first.el_: std::numeric_limits<T>::max();
+        if(list_.size() == wsz_) return map_.begin()->first.el_;
+        if(std::is_same<T, u128>::value)
+            return u128(-1);
+        return std::numeric_limits<T>::max();
         // Signal a window that is not filled by 0xFFFFFFFFFFFFFFFF
     }
     void reset() {
@@ -87,7 +90,11 @@ class QueueMap {
     }
     size_t size() const {return wsz_;}
     size_t n_in_queue() const {return list_.size();}
-    bool partially_full() const {auto n = n_in_queue(); return n > 0u && n < wsz_;}
+    bool partially_full() const {
+        const auto n = n_in_queue();
+        return n > 0u && n < wsz_;
+    }
+    const auto &max_in_queue() const {return begin()->first;}
 };
 
 using qmap_t = QueueMap<u64, u64>;

--- a/python/download_genomes.py
+++ b/python/download_genomes.py
@@ -63,7 +63,8 @@ ALL_CLADES_MAP = {
     "protozoa": FTP_BASENAME + "protozoa/",
     "human": FTP_BASENAME + "vertebrate_mammalian/Homo_sapiens",
     "vertebrate_mammalian": FTP_BASENAME + "vertebrate_mammalian/",
-    "vertebrate_other": FTP_BASENAME + "vertebrate_other/"
+    "vertebrate_other": FTP_BASENAME + "vertebrate_other/",
+    "invertebrate": FTP_BASENAME + "invertebrate/"
 }
 
 DEFAULT_CLADES = [

--- a/test/encoding.cpp
+++ b/test/encoding.cpp
@@ -153,18 +153,14 @@ TEST_CASE( "Spacer encodes and decodes contiguous, unminimized seeds correctly."
 }
 TEST_CASE("rollin_spaced") {
     RollingHasher<__uint128_t, CyclicHash<__uint128_t>> enc(100, /*canon = */false, /*alphabet=*/bns::PROTEIN, /*wsz=*/200);
-    gzFile fp = gzopen("test/phix.fa", "rb");
-    if(!fp) throw "a party!";
     __uint128_t total_hash = 0;
-    enc.for_each_hash([&total_hash](auto) {++total_hash;}, fp);
+    enc.for_each_hash([&total_hash](auto) {++total_hash;}, "test/phix.fa");
     REQUIRE(uint64_t(total_hash) == uint64_t(5386 - 200 + 1));
-    gzrewind(fp);
     size_t xor_red = 0;
     Encoder<> enc3(31);
-    enc3.for_each_hash([&](uint64_t x) {xor_red |= x;}, fp);
+    enc3.for_each_hash([&](uint64_t x) {xor_red |= x;}, "test/phix.fa");
     Encoder<> enc4(147);
-    enc3.for_each_hash([&](uint64_t x) {xor_red |= x;}, fp);
-    gzclose(fp);
+    enc3.for_each_hash([&](uint64_t x) {xor_red |= x;}, "test/phix.fa");
 }
 TEST_CASE("rollin") {
     RollingHasher<__uint128_t, CyclicHash<__uint128_t>> enc(100);
@@ -187,8 +183,10 @@ TEST_CASE("rollin") {
 }
 TEST_CASE("rhs") {
     RollingHasherSet<uint64_t> rhs(std::vector<int>{16,32,64,128});
-    rhs.for_each_hash([](uint64_t kmer, size_t hashnum) {std::fprintf(stderr, "%" PRIu64 ": %zu\n", kmer, hashnum);},
+    std::FILE *ofp = std::fopen("/dev/null", "wb");
+    rhs.for_each_hash([ofp](uint64_t kmer, size_t hashnum) {std::fprintf(ofp, "%" PRIu64 ": %zu\n", kmer, hashnum);},
                       "test/phix.fa");
+    std::fclose(ofp);
 }
 TEST_CASE("entmin") {
     Spacer sp(31, 60);

--- a/test/util.cpp
+++ b/test/util.cpp
@@ -4,7 +4,7 @@ using namespace bns;
 
 #define is_pow2(x) ((x & (x - 1)) == 0)
 
-TEST_CASE("Khash writes and reads correcly") {
+TEST_CASE("KhashSerial") {
     khash_t(c) *th(kh_init(c)), *ti(nullptr);
     khint_t ki;
     int khr;


### PR DESCRIPTION
This changes windowed minimizer generation for sequences of length > k but < w.

If the window of minimizers is not full but no minimizers have been generated, bonsai will yield the hash argmin for the window. For example, "AABCD" shingling with k = 3 and w = 8 now yields a single minimizer ("AAB", if the hash function is lexicographic) instead of 0 of them. "AA" still yields an empty sequence of minimizers.

Additionally, we added invertebrate genomes to RefSeq scraping.